### PR TITLE
fix: check whether whitelist element contains current target or not

### DIFF
--- a/src/ClickOutside/index.js
+++ b/src/ClickOutside/index.js
@@ -10,10 +10,15 @@ const ClickOutside = {
   created () {
     if (!this.isDisabled) {
       const listener = (e, el) => {
+        const whitelistContainsTarget = this.whitelist.reduce((_, whitelistElement) => {
+          return whitelistElement && whitelistElement.contains(e.target);
+        }, false);
+
         if (
           e.target === el ||
           el.contains(e.target) ||
-          (this.whitelist.includes(e.target))
+          (this.whitelist.includes(e.target)) ||
+          whitelistContainsTarget
         ) return
         if (this.do) this.do()
       }


### PR DESCRIPTION
Hi mate, you know the issue :D

codesandbox: https://codesandbox.io/s/popper-vue-bug-bhw3x

Steps to reproduce:
when i click the `text` inside of `button` it works. 
when i click any element for example the `span` inside of `button` it doesn't work. But it should.



