### PR TITLE
Added SVGPathElement support

### DIFF
--- a/src/Popper/index.js
+++ b/src/Popper/index.js
@@ -42,7 +42,7 @@ const Popper = {
       type: Object,
       default: () => {}
     },
-    anchorEl: [HTMLElement, Object],
+    anchorEl: [HTMLElement, SVGPathElement, Object],
     eventsEnabled: {
       type: Boolean,
       default: true
@@ -162,6 +162,7 @@ const Popper = {
      * @returns {Vue.VNode}
      */
     bindArrowClass (node) {
+      if (!node[0].data) node[0].data = {}
       if (node[0].data['staticClass']) node[0].data['staticClass'] += ' popper-vue'
       else node[0].data['staticClass'] = 'popper-vue'
       return node


### PR DESCRIPTION
Hello,

I needed to add popover on _SVGPathElement_ object, but it was impossible to do it.
I've added the _SVGPathElement_ to _anchorEl_ and now it is working.

About changes in the _bindArrowClass_ method:
Check related image. I've got undefined data in _node[0]_. That's why I created a new object.

![data0](https://user-images.githubusercontent.com/16820437/93468620-f0df5480-f8f7-11ea-9234-d4c3795df2b3.png)

Daniel